### PR TITLE
Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Authors@R: c(
     person("Marley", "Basset", role = c("aut", "dtc")),
     person("Eva", "Schindler", role = c("aut", "dtc")),
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", c("aut", "cre", "dtc"), comment = c(ORCID = "0000-0002-7683-4592")),
-    person("Evan", "Amies-Galonski", role = "aut"),
+    person("Evan", "Amies-Galonski", role = "aut",
+           comment = c(ORCID = "0000-0003-1096-2089")),
     person("Rhonda", "Gates", role = "dtc"),
     person("Jess", "Spencer", role = "dtc")
     )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Version: 0.3.1.9001
 Authors@R: c(
     person("Jeff", "Burrows", role = c("aut", "dtc")),
     person("Matt", "Neufeld", role = c("aut", "dtc")),
-    person("Greg", "Andrusak", role = c("aut", "dtc")),
+    person("Greg", "Andrusak", role = c("aut", "dtc"),
+           comment = c(ORCID = "0009-0008-0093-8521")),
     person("Marley", "Basset", role = c("aut", "dtc")),
     person("Eva", "Schindler", role = c("aut", "dtc")),
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", c("aut", "cre", "dtc"), comment = c(ORCID = "0000-0002-7683-4592")),


### PR DESCRIPTION
Add Evan Amies-Galonski's ORCID (0000-0003-1096-2089).

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)